### PR TITLE
Fix broken `break` statements

### DIFF
--- a/notify_listener.go
+++ b/notify_listener.go
@@ -89,6 +89,7 @@ func (l *NotifyListener) ListenForChanges(ctx context.Context) (chan *Changeset,
 
 			go l.store.GetSinceID(ctx, *l.startFromID, eventCh, doneCh, errCh)
 
+		processIDLoop:
 			for {
 				select {
 				case c := <-eventCh:
@@ -99,7 +100,7 @@ func (l *NotifyListener) ListenForChanges(ctx context.Context) (chan *Changeset,
 				case <-doneCh:
 					close(errCh)
 					close(eventCh)
-					break
+					break processIDLoop
 				}
 			}
 		} else if l.startFromTimestamp != nil {
@@ -109,6 +110,7 @@ func (l *NotifyListener) ListenForChanges(ctx context.Context) (chan *Changeset,
 
 			go l.store.GetSinceTimestamp(ctx, *l.startFromTimestamp, eventCh, doneCh, errCh)
 
+		processTimestampLoop:
 			for {
 				select {
 				case c := <-eventCh:
@@ -119,7 +121,7 @@ func (l *NotifyListener) ListenForChanges(ctx context.Context) (chan *Changeset,
 				case <-doneCh:
 					close(errCh)
 					close(eventCh)
-					break
+					break processTimestampLoop
 				}
 			}
 		}


### PR DESCRIPTION
OK, so, I think what's going on here is, when we pull a message off doneCh, we want to close the channels and then move on to the waitForNotification code. But `break` is in fact breaking out of the `select`, not the `for`. So when we get a message off doneCh, it's looping back around and pulling messages off of closed channels. We need to break out of the outer loop. Not sure why this didn't cause issues before today.

I think there's another issue that I'm not trying to fix in this PR. If `eventCh` and `doneCh` both have messages on them (i.e. the producer is running ahead of the consumer), the `select` is allowed to pull the message from `doneCh` and any messages on `eventCh` will be dropped.