### PR TITLE
refactor: Allow access to the Axon worker

### DIFF
--- a/axon.go
+++ b/axon.go
@@ -1,0 +1,186 @@
+package warppipe
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/kelseyhightower/envconfig"
+	"github.com/sirupsen/logrus"
+)
+
+func getDBConnString(host string, port int, name, user, pass string) string {
+	return fmt.Sprintf("user=%s password=%s dbname=%s host=%s port=%d sslmode=%s",
+		user,
+		pass,
+		name,
+		host,
+		port,
+		"disable",
+	)
+}
+
+type Axon struct {
+	Config *AxonConfig
+	Logger *logrus.Logger
+}
+
+func NewAxonConfigFromEnv() (*AxonConfig, error) {
+	config := AxonConfig{}
+	err := envconfig.Process("axon", &config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process environment config: %w", err)
+	}
+	return &config, nil
+}
+
+func (a *Axon) Run() {
+	shutdownCh := make(chan os.Signal)
+	signal.Notify(shutdownCh, os.Interrupt, syscall.SIGTERM)
+
+	if a.Logger == nil {
+		a.Logger = logrus.New()
+		a.Logger.SetFormatter(&logrus.JSONFormatter{})
+	}
+
+	// TODO: Refactor to use just one connection to the sourceDB
+	sourceDBConn, err := sqlx.Open("postgres", getDBConnString(
+		a.Config.SourceDBHost,
+		a.Config.SourceDBPort,
+		a.Config.SourceDBName,
+		a.Config.SourceDBUser,
+		a.Config.SourceDBPass,
+	))
+	if err != nil {
+		a.Logger.WithError(err).Fatal("unable to connect to source database")
+	}
+
+	targetDBConn, err := sqlx.Open("postgres", getDBConnString(
+		a.Config.TargetDBHost,
+		a.Config.TargetDBPort,
+		a.Config.TargetDBName,
+		a.Config.TargetDBUser,
+		a.Config.TargetDBPass,
+	))
+	if err != nil {
+		a.Logger.WithError(err).Fatal("unable to connect to target database")
+	}
+
+	err = checkTargetVersion(targetDBConn)
+	if err != nil {
+		a.Logger.WithError(err).Fatal("unable to check target database version")
+	}
+
+	// TODO: (1) add support for selecting the warp-pipe mode
+	// TODO: (2) only print the source stats if that is audit
+	err = printSourceStats(sourceDBConn)
+	if err != nil {
+		a.Logger.WithError(err).Fatal("unable to get source db stats")
+	}
+
+	err = loadPrimaryKeys(targetDBConn)
+	if err != nil {
+		a.Logger.WithError(err).Fatal("unable to load target DB primary keys")
+	}
+
+	err = loadColumnSequences(targetDBConn)
+	if err != nil {
+		a.Logger.WithError(err).Fatal("unable to load target DB column sequences")
+	}
+
+	err = loadOrphanSequences(sourceDBConn)
+	if err != nil {
+		a.Logger.WithError(err).Fatal("unable to load source DB orphan sequences")
+	}
+
+	// create a notify listener and start from changeset id 1
+	listener := NewNotifyListener(StartFromID(0))
+	wp := NewWarpPipe(listener)
+	err = wp.Open(&DBConfig{
+		Host:     a.Config.SourceDBHost,
+		Port:     a.Config.SourceDBPort,
+		Database: a.Config.SourceDBName,
+		User:     a.Config.SourceDBUser,
+		Password: a.Config.SourceDBPass,
+	})
+	if err != nil {
+		a.Logger.WithError(err).
+			WithField("component", "warp_pipe").
+			Fatal("unable to connect to source database")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	changes, errs := wp.ListenForChanges(ctx)
+
+	go func() {
+		<-shutdownCh
+		a.Logger.Error("shutting down...")
+		cancel()
+		wp.Close()
+		sourceDBConn.Close()
+		targetDBConn.Close()
+		os.Exit(0)
+	}()
+
+	for {
+		select {
+		case err := <-errs:
+			a.Logger.WithError(err).
+				WithField("component", "warp_pipe").
+				Error("received an error")
+		case change := <-changes:
+			a.processChange(sourceDBConn, targetDBConn, a.Config.TargetDBSchema, change)
+
+		}
+	}
+}
+
+func (a *Axon) processChange(sourceDB *sqlx.DB, targetDB *sqlx.DB, schema string, change *Changeset) {
+	switch change.Kind {
+	case ChangesetKindInsert:
+		a.processInsert(sourceDB, targetDB, schema, change)
+	case ChangesetKindUpdate:
+		a.processUpdate(targetDB, schema, change)
+	case ChangesetKindDelete:
+		a.processDelete(targetDB, schema, change)
+	}
+}
+
+func (a *Axon) processDelete(targetDB *sqlx.DB, schema string, change *Changeset) {
+	pk, err := getPrimaryKeyForChange(change)
+	if err != nil {
+		a.Logger.WithError(err).WithField("table", change.Table).
+			Errorf("unable to process DELETE for table '%s', changeset has no primary key", change.Table)
+	}
+
+	err = deleteRow(targetDB, schema, change, pk)
+	if err != nil {
+		a.Logger.WithError(err).WithField("table", change.Table).
+			Errorf("failed to DELETE row for table '%s' (pk: %s)", change.Table, pk)
+	}
+}
+
+func (a *Axon) processInsert(sourceDB *sqlx.DB, targetDB *sqlx.DB, schema string, change *Changeset) {
+	err := insertRow(sourceDB, targetDB, schema, change)
+	if err != nil {
+		a.Logger.WithError(err).WithField("table", change.Table).
+			Errorf("failed to INSERT row for table '%s'", change.Table)
+	}
+}
+
+func (a *Axon) processUpdate(targetDB *sqlx.DB, schema string, change *Changeset) {
+	pk, err := getPrimaryKeyForChange(change)
+	if err != nil {
+		a.Logger.WithError(err).WithField("table", change.Table).
+			Errorf("unable to process UPDATE for table '%s', changeset has no primary key", change.Table)
+	}
+
+	err = updateRow(targetDB, schema, change, pk)
+	if err != nil {
+		a.Logger.WithError(err).WithField("table", change.Table).
+			Errorf("failed to UPDATE row for table '%s' (pk: %s)", change.Table, pk)
+	}
+}

--- a/axon_config.go
+++ b/axon_config.go
@@ -1,7 +1,7 @@
-package main
+package warppipe
 
-// Config store configuration for axon
-type Config struct {
+// AxonConfig store configuration for axon
+type AxonConfig struct {
 	// source db credentials
 	SourceDBHost string `envconfig:"source_db_host"`
 	SourceDBPort int    `envconfig:"source_db_port"`

--- a/axon_schema.go
+++ b/axon_schema.go
@@ -1,4 +1,4 @@
-package main
+package warppipe
 
 import (
 	"fmt"
@@ -8,7 +8,6 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
-	warppipe "github.com/perangel/warp-pipe"
 )
 
 // maps primary key columns by table
@@ -87,7 +86,7 @@ func loadPrimaryKeys(conn *sqlx.DB) error {
 	return nil
 }
 
-func getPrimaryKeyForChange(change *warppipe.Changeset) ([]string, error) {
+func getPrimaryKeyForChange(change *Changeset) ([]string, error) {
 	col, ok := primaryKeys[change.Table]
 	if !ok {
 		return nil, fmt.Errorf("no primary key in mapping for table `%s`", change.Table)
@@ -135,7 +134,7 @@ func getSequenceColumns(table, column string) (string, bool) {
 	return "", false
 }
 
-func updateColumnSequence(conn *sqlx.DB, table string, columns []*warppipe.ChangesetColumn) error {
+func updateColumnSequence(conn *sqlx.DB, table string, columns []*ChangesetColumn) error {
 	// Why no transaction? From the manual: Because sequences are
 	// non-transactional, changes made by setval are not undone if the transaction
 	// rolls back.
@@ -195,7 +194,7 @@ func loadOrphanSequences(conn *sqlx.DB) error {
 	return nil
 }
 
-func updateOrphanSequences(sourceDB *sqlx.DB, targetDB *sqlx.DB, table string, columns []*warppipe.ChangesetColumn) error {
+func updateOrphanSequences(sourceDB *sqlx.DB, targetDB *sqlx.DB, table string, columns []*ChangesetColumn) error {
 	for _, sequenceName := range orphanSequences {
 		var lastVal int64 // PG bigint is 8 bytes
 

--- a/cmd/axon/main.go
+++ b/cmd/axon/main.go
@@ -1,188 +1,21 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
-
-	"github.com/jmoiron/sqlx"
-	"github.com/kelseyhightower/envconfig"
 	_ "github.com/lib/pq"
-	warppipe "github.com/perangel/warp-pipe"
 	"github.com/sirupsen/logrus"
+
+	warppipe "github.com/perangel/warp-pipe"
 )
 
-var (
-	logger *logrus.Logger
-)
-
-func init() {
-	logger = logrus.New()
+func main() {
+	logger := logrus.New()
 	logger.SetFormatter(&logrus.JSONFormatter{})
-}
 
-func getDBConnString(host string, port int, name, user, pass string) string {
-	return fmt.Sprintf("user=%s password=%s dbname=%s host=%s port=%d sslmode=%s",
-		user,
-		pass,
-		name,
-		host,
-		port,
-		"disable",
-	)
-}
-
-func parseConfig() *Config {
-	var config Config
-	err := envconfig.Process("axon", &config)
+	cfg, err := warppipe.NewAxonConfigFromEnv()
 	if err != nil {
 		logger.WithError(err).Fatal("failed to process environment config")
 	}
-	return &config
-}
 
-func main() {
-	config := parseConfig()
-	shutdownCh := make(chan os.Signal)
-	signal.Notify(shutdownCh, os.Interrupt, syscall.SIGTERM)
-
-	// TODO: Refactor to use just one connection to the sourceDB
-	sourceDBConn, err := sqlx.Open("postgres", getDBConnString(
-		config.SourceDBHost,
-		config.SourceDBPort,
-		config.SourceDBName,
-		config.SourceDBUser,
-		config.SourceDBPass,
-	))
-	if err != nil {
-		logger.WithError(err).Fatal("unable to connect to source database")
-	}
-
-	targetDBConn, err := sqlx.Open("postgres", getDBConnString(
-		config.TargetDBHost,
-		config.TargetDBPort,
-		config.TargetDBName,
-		config.TargetDBUser,
-		config.TargetDBPass,
-	))
-	if err != nil {
-		logger.WithError(err).Fatal("unable to connect to target database")
-	}
-
-	err = checkTargetVersion(targetDBConn)
-	if err != nil {
-		logger.WithError(err).Fatal("unable to check target database version")
-	}
-
-	// TODO: (1) add support for selecting the warp-pipe mode
-	// TODO: (2) only print the source stats if that is audit
-	err = printSourceStats(sourceDBConn)
-	if err != nil {
-		logger.WithError(err).Fatal("unable to get source db stats")
-	}
-
-	err = loadPrimaryKeys(targetDBConn)
-	if err != nil {
-		logger.WithError(err).Fatal("unable to load target DB primary keys")
-	}
-
-	err = loadColumnSequences(targetDBConn)
-	if err != nil {
-		logger.WithError(err).Fatal("unable to load target DB column sequences")
-	}
-
-	err = loadOrphanSequences(sourceDBConn)
-	if err != nil {
-		logger.WithError(err).Fatal("unable to load source DB orphan sequences")
-	}
-
-	// create a notify listener and start from changeset id 1
-	listener := warppipe.NewNotifyListener(warppipe.StartFromID(0))
-	wp := warppipe.NewWarpPipe(listener)
-	err = wp.Open(&warppipe.DBConfig{
-		Host:     config.SourceDBHost,
-		Port:     config.SourceDBPort,
-		Database: config.SourceDBName,
-		User:     config.SourceDBUser,
-		Password: config.SourceDBPass,
-	})
-	if err != nil {
-		logger.WithError(err).
-			WithField("component", "warp_pipe").
-			Fatal("unable to connect to source database")
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	changes, errs := wp.ListenForChanges(ctx)
-
-	go func() {
-		<-shutdownCh
-		logger.Error("shutting down...")
-		cancel()
-		wp.Close()
-		sourceDBConn.Close()
-		targetDBConn.Close()
-		os.Exit(0)
-	}()
-
-	for {
-		select {
-		case err := <-errs:
-			logger.WithError(err).
-				WithField("component", "warp_pipe").
-				Error("received an error")
-		case change := <-changes:
-			processChange(sourceDBConn, targetDBConn, config.TargetDBSchema, change)
-
-		}
-	}
-}
-
-func processChange(sourceDB *sqlx.DB, targetDB *sqlx.DB, schema string, change *warppipe.Changeset) {
-	switch change.Kind {
-	case warppipe.ChangesetKindInsert:
-		processInsert(sourceDB, targetDB, schema, change)
-	case warppipe.ChangesetKindUpdate:
-		processUpdate(targetDB, schema, change)
-	case warppipe.ChangesetKindDelete:
-		processDelete(targetDB, schema, change)
-	}
-}
-
-func processDelete(targetDB *sqlx.DB, schema string, change *warppipe.Changeset) {
-	pk, err := getPrimaryKeyForChange(change)
-	if err != nil {
-		logger.WithError(err).WithField("table", change.Table).
-			Errorf("unable to process DELETE for table '%s', changeset has no primary key", change.Table)
-	}
-
-	err = deleteRow(targetDB, schema, change, pk)
-	if err != nil {
-		logger.WithError(err).WithField("table", change.Table).
-			Errorf("failed to DELETE row for table '%s' (pk: %s)", change.Table, pk)
-	}
-}
-
-func processInsert(sourceDB *sqlx.DB, targetDB *sqlx.DB, schema string, change *warppipe.Changeset) {
-	err := insertRow(sourceDB, targetDB, schema, change)
-	if err != nil {
-		logger.WithError(err).WithField("table", change.Table).
-			Errorf("failed to INSERT row for table '%s'", change.Table)
-	}
-}
-
-func processUpdate(targetDB *sqlx.DB, schema string, change *warppipe.Changeset) {
-	pk, err := getPrimaryKeyForChange(change)
-	if err != nil {
-		logger.WithError(err).WithField("table", change.Table).
-			Errorf("unable to process UPDATE for table '%s', changeset has no primary key", change.Table)
-	}
-
-	err = updateRow(targetDB, schema, change, pk)
-	if err != nil {
-		logger.WithError(err).WithField("table", change.Table).
-			Errorf("failed to UPDATE row for table '%s' (pk: %s)", change.Table, pk)
-	}
+	axon := warppipe.Axon{Config: cfg, Logger: logger}
+	axon.Run()
 }


### PR DESCRIPTION
Moves Axon worker code into the root of the project, and exposes it using `Axon.Run()`. This reduces code
duplication when using the Warp-Pipe package externally. Later Axon methods could be migrated to the WarpPipe receiver
struct.