### PR TITLE
Add changeset ID to string representation of a changeset

### DIFF
--- a/axon.go
+++ b/axon.go
@@ -107,8 +107,8 @@ func (a *Axon) Run() error {
 		return fmt.Errorf("unable to load source DB orphan sequences: %w", err)
 	}
 
-	// create a notify listener and start from changeset id 1
-	listener := NewNotifyListener(StartFromID(0))
+	// Create a notify listener and start from the configured changeset id.
+	listener := NewNotifyListener(StartFromID(a.Config.StartFromID))
 
 	connConfig := pgx.ConnConfig{
 		Host:     a.Config.SourceDBHost,

--- a/axon_config.go
+++ b/axon_config.go
@@ -19,4 +19,7 @@ type AxonConfig struct {
 
 	// force Axon to shutdown after processing the latest changeset
 	ShutdownAfterLastChangeset bool `envconfig:"shutdown_after_last_changeset"`
+
+	// start the axon run from the specified changeset id. defaults to 0.
+	StartFromID int64 `envconfig:"start_from_id" default:"0"`
 }

--- a/axon_sql.go
+++ b/axon_sql.go
@@ -155,7 +155,9 @@ func insertRow(sourceDB *sqlx.DB, targetDB *sqlx.DB, change *Changeset) error {
 		return err
 	}
 
-	log.Printf("row inserted: %s", change)
+	// NOTE: row insert/update/delete logs have been updated to be the same length
+	// to align timestamps to ease viewing.
+	log.Printf("row insert: %s", change)
 	return nil
 }
 
@@ -175,7 +177,7 @@ func updateRow(targetDB *sqlx.DB, change *Changeset, primaryKey []string) error 
 
 		return fmt.Errorf("PG error %s:%s failed to update %s for query %s args %s: %+v", pqe.Code, pqe.Code.Name(), change, removeDuplicateSpaces(query), args, err)
 	}
-	log.Printf("row updated: %s", change)
+	log.Printf("row update: %s", change)
 	return nil
 }
 
@@ -189,6 +191,6 @@ func deleteRow(targetDB *sqlx.DB, change *Changeset, primaryKey []string) error 
 		}
 		return fmt.Errorf("PG error %s:%s delete to update %s for query %s: %+v", pqe.Code, pqe.Code.Name(), change, removeDuplicateSpaces(query), err)
 	}
-	log.Printf("row deleted: %s", change)
+	log.Printf("row delete: %s", change)
 	return nil
 }

--- a/axon_sql.go
+++ b/axon_sql.go
@@ -34,7 +34,7 @@ func prepareQueryArgs(changesetCols []*ChangesetColumn) ([]string, []string, map
 			// empty character varying[]: "unsupported type []interface {}, a slice of
 			// interface"
 			if reflect.ValueOf(c.Value).Len() == 0 {
-				c.Value = pq.Array(nil)
+				c.Value = []byte("{}")
 			} else {
 				c.Value = pq.Array(c.Value)
 			}

--- a/changeset.go
+++ b/changeset.go
@@ -58,7 +58,7 @@ func (c *Changeset) String() string {
 	// While c.newValues is an ordered array, the original data source is a JSON
 	// object used as a hashmap, therefore the data is stored as a map in Go
 	// which means the field order in the array is randomized.
-	return fmt.Sprintf("{timestamp: %s, kind: %s, schema: %s, table: %s}", c.Timestamp, c.Kind, c.Schema, c.Table)
+	return fmt.Sprintf("{id: %d, timestamp: %s, kind: %s, schema: %s, table: %s}", c.ID, c.Timestamp, c.Kind, c.Schema, c.Table)
 }
 
 // GetNewColumnValue returns the current value for a column and a bool denoting

--- a/cmd/axon/main.go
+++ b/cmd/axon/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	_ "github.com/lib/pq"
 	"github.com/sirupsen/logrus"
 
@@ -17,5 +19,8 @@ func main() {
 	}
 
 	axon := warppipe.Axon{Config: cfg, Logger: logger}
-	axon.Run()
+	err = axon.Run()
+	if err != nil {
+		fmt.Printf("ERROR: %s\n", err.Error())
+	}
 }


### PR DESCRIPTION
This came up during today's migration call, seems like handy information to have.